### PR TITLE
Add compact_panel option, modify show_full_path option, add ability to close views

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["ctrl+alt+tab"], "command": "extended_switcher", "args": {"list_mode": "window"} },
-    { "keys": ["ctrl+alt+shift+tab"], "command": "extended_switcher", "args": {"list_mode": "active_group"} }
+    { "keys": ["ctrl+alt+shift+tab"], "command": "extended_switcher", "args": {"list_mode": "active_group"} },
+    { "keys": ["delete"], "command": "extended_switcher", "args": {"cmd": "close_view"},
+        "context": [ {"key": "extended_switcher_active"}] }
 ]
-	

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["ctrl+alt+tab"], "command": "extended_switcher", "args": {"list_mode": "window"} },
-    { "keys": ["ctrl+alt+shift+tab"], "command": "extended_switcher", "args": {"list_mode": "active_group"} }
+    { "keys": ["ctrl+alt+shift+tab"], "command": "extended_switcher", "args": {"list_mode": "active_group"} },
+    { "keys": ["delete"], "command": "extended_switcher", "args": {"cmd": "close_view"},
+        "context": [ {"key": "extended_switcher_active"}] }
 ]
-	

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,5 +1,6 @@
 [
     { "keys": ["ctrl+alt+tab"], "command": "extended_switcher", "args": {"list_mode": "window"} },
-    { "keys": ["ctrl+alt+shift+tab"], "command": "extended_switcher", "args": {"list_mode": "active_group"} }
+    { "keys": ["ctrl+alt+shift+tab"], "command": "extended_switcher", "args": {"list_mode": "active_group"} },
+    { "keys": ["delete"], "command": "extended_switcher", "args": {"cmd": "close_view"},
+        "context": [ {"key": "extended_switcher_active"}] }
 ]
-	

--- a/ExtendedSwitcher.py
+++ b/ExtendedSwitcher.py
@@ -10,6 +10,7 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 	# lets go
 	def run(self, list_mode):
 		# self.view.insert(edit, 0, "Hello, World!")
+		self.group = self.window.active_group()
 		self.open_files = []
 		self.open_views = []
 		self.window = sublime.active_window()
@@ -57,6 +58,8 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 	# display the selected open file
 	def tab_selected(self, selected):
 		if selected > -1:
+			if self.settings.get('move_to_current_pane') == True:
+				self.window.set_view_index(self.open_views[selected], self.group, 0)
 			self.window.focus_view(self.open_views[selected])
 
 		return selected

--- a/ExtendedSwitcher.py
+++ b/ExtendedSwitcher.py
@@ -1,5 +1,20 @@
 import sublime, sublime_plugin, os
 
+last_highlighted_view = None
+
+class ExtendedSwitcherListener(sublime_plugin.EventListener):
+	def on_query_context(self, view, key, operator, operand, match_all):
+		def test(a):
+			if operator == sublime.OP_EQUAL:
+				return a == operand
+			if operator == sublime.OP_NOT_EQUAL:
+				return a != operand
+			return False
+
+		if key == "extended_switcher_active":
+			return test(last_highlighted_view is not None)
+
+
 class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 	# declarations
 	open_files = []
@@ -8,14 +23,24 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 	settings = []
 
 	# lets go
-	def run(self, list_mode):
+	def run(self, list_mode='window', cmd='show_switcher'):
+		if cmd == 'close_view':
+			if last_highlighted_view and not last_highlighted_view.is_dirty():
+				window = last_highlighted_view.window()
+				if window:
+					active = window.active_view_in_group(window.active_group())
+					window.focus_view(last_highlighted_view)
+					window.run_command('close')
+					window.focus_view(active)
+			return
+
 		# self.view.insert(edit, 0, "Hello, World!")
 		self.open_files = []
 		self.open_views = []
 		self.window = sublime.active_window()
 		self.settings = sublime.load_settings('ExtendedSwitcher.sublime-settings')
 		folders = self.window.folders()
-		
+
 		for f in self.getViews(list_mode):
 			# if skip the current active is enabled do not add the current file it for selection
 			if self.settings.get('skip_current_file') == True:
@@ -31,13 +56,15 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 					if os.path.commonprefix([folder, file_name]) == folder:
 						file_path = os.path.relpath(file_name, folder)
 
+				# if there are any unsaved changes to the file, add a mark character
 				if f.is_dirty():
-					file_name += self.settings.get('mark_dirty_file_char') # if there are any unsaved changes to the file
+					file_name += self.settings.get('mark_dirty_file_char')
+					file_path += self.settings.get('mark_dirty_file_char')
 
-				if self.settings.get('show_full_file_path') == True:
-					self.open_files.append([os.path.basename(file_name), file_path]) 
+				if self.settings.get('show_full_file_path'):
+					self.open_files.append([os.path.basename(file_name), file_path])
 				else:
-					self.open_files.append([os.path.basename(file_name), '']) 
+					self.open_files.append([os.path.basename(file_name), ''])
 			elif f.name():
 				if f.is_dirty():
 					self.open_files.append([f.name() + self.settings.get('mark_dirty_file_char'), ''])
@@ -51,11 +78,27 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 
 		if self.check_for_sorting() == True:
 			self.sort_files()
- 
-		self.window.show_quick_panel(self.open_files, self.tab_selected, False, -1) # show the file list
+
+		if self.settings.get('show_full_file_path') == "first":
+			self.open_files = [[x[1], x[0]] if x[1] else [x[0], x[1]] for x in self.open_files]
+
+		quick_panel_list = self.open_files
+		if self.settings.get('compact_panel') == True:
+			quick_panel_list = [x[0] if x[0] else x[1] for x in self.open_files]
+
+		# show the file list
+		self.window.show_quick_panel(quick_panel_list, self.tab_selected,
+									 False, -1, self.tab_highlighted)
+
+	def tab_highlighted(self, selected):
+		global last_highlighted_view
+		last_highlighted_view = self.open_views[selected]
 
 	# display the selected open file
 	def tab_selected(self, selected):
+		global last_highlighted_view
+		last_highlighted_view = None
+
 		if selected > -1:
 			self.window.focus_view(self.open_views[selected])
 
@@ -83,7 +126,6 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 					open_views.append(fv)
 					self.open_views.remove(fv)
 
-				
 		self.open_views = open_views
 
 
@@ -105,5 +147,3 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 			views = self.window.views()
 
 		return views
-
-

--- a/ExtendedSwitcher.sublime-settings
+++ b/ExtendedSwitcher.sublime-settings
@@ -1,5 +1,5 @@
 {
-	// sort the files 
+	// sort the files
 	"sort": true,
 
 	// Don't list current file?
@@ -9,7 +9,11 @@
 	// Also handy for filterig dirty files, if you type this string while the list is visible:
 	"mark_dirty_file_char" : "*",
 
-	//show full path with the filename
-	"show_full_file_path": true
-}
+	// If true, shows the full file path on the second row of the quick panel
+	// If equal to "first", shows the full file path on the first row  of the quick
+	//    panel, with the filename on the second
+	"show_full_file_path": true,
 
+	// If true, only shows one row per file in the quick switcher.
+	"compact_panel": false
+}

--- a/ExtendedSwitcher.sublime-settings
+++ b/ExtendedSwitcher.sublime-settings
@@ -10,6 +10,10 @@
 	"mark_dirty_file_char" : "*",
 
 	//show full path with the filename
-	"show_full_file_path": true
+	"show_full_file_path": true,
+
+    // When set to true, the tab will be moved to the currently active
+    // pane, in case it was elsewhere.
+    "move_to_current_pane": false
 }
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Extended tab switcher for Sublime Text
 
 * On pressing `ctrl+alt+tab` all open files will be displayed for selection.
 * On pressing `ctrl+alt+shift+tab` only open files in the active group will be displayed for selection.
+* On pressing `delete` while the tab switcher is shown, the highlighted file will be closed, if it has no modifications.
 
 
 User can change the default key binding at `Preferences -> Package Settings -> Extended Tab Switcher -> Key Bindings User`
@@ -48,21 +49,36 @@ User can overwrite the following configurations by adding flags in the User - Se
 
 	```javascript
 	{
-		"mark_dirty_file_char": "<your-char>" 
+		"mark_dirty_file_char": "<your-char>"
 	}
 
 	```
 
-* Show full file path 
-	
-	By default the files listed will contain only the filename, This can be overwritten by adding the following flag in the settings
+* Show full file path
+
+	By default the files listed will contain only the filename, This can be
+	overwritten by adding the following flag in the settings. If set to true, the
+	path will be listed below the filename. If set to "first", the path will be
+	listed above the filename.
 
 	```javascript
 	{
-		"show_full_file_path": true 
+		"show_full_file_path": true
 	}
 
 	```
+
+* Make the file display more compact
+
+	By default, each file gets two lines of information in the switcher panel. Show only the first line by setting the following flag in the settings
+
+	```javascript
+	{
+		"compact_panel": true
+	}
+
+	```
+
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ User can overwrite the following configurations by adding flags in the User - Se
 
 	```
 
+* Open tabs in the current pane
+
+	By default, selecting a file will focus its view in its current position. When the following flag is set to true, the view will be moved into the currently active pane.
+
+	```javascript
+	{
+		"move_to_current_pane": false
+	}
+
+	```
 
 ## Credits
 


### PR DESCRIPTION
I have usee the extended tab switcher a lot over the last couple months. Thanks for making it! I have added options so that I can show the full file path on a single line (thus seeing more buffers in less space), and also added a command to close the highlighted view. Let me know what you think. 
