### PR TITLE
Added the capability to move tabs to the currently active pane

### DIFF
--- a/ExtendedSwitcher.py
+++ b/ExtendedSwitcher.py
@@ -10,6 +10,7 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 	# lets go
 	def run(self, list_mode):
 		# self.view.insert(edit, 0, "Hello, World!")
+		self.group = self.window.active_group()
 		self.open_files = []
 		self.open_views = []
 		self.window = sublime.active_window()
@@ -57,6 +58,8 @@ class ExtendedSwitcherCommand(sublime_plugin.WindowCommand):
 	# display the selected open file
 	def tab_selected(self, selected):
 		if selected > -1:
+			if self.settings.get('move_to_current_pane') == True:
+				self.window.set_view_index(self.open_views[selected], self.group, 0)
 			self.window.focus_view(self.open_views[selected])
 
 		return selected

--- a/ExtendedSwitcher.sublime-settings
+++ b/ExtendedSwitcher.sublime-settings
@@ -10,6 +10,10 @@
 	"mark_dirty_file_char" : "*",
 
 	//show full path with the filename
-	"show_full_file_path": true
+	"show_full_file_path": true,
+
+    // When set to true, the tab will be moved to the currently active
+    // pane, in case it was elsewhere.
+    "move_to_current_pane": false
 }
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ User can overwrite the following configurations by adding flags in the User - Se
 
 	```
 
+* Open tabs in the current pane
+
+	By default, selecting a file will focus its view in its current position. When the following flag is set to true, the view will be moved into the currently active pane.
+
+	```javascript
+	{
+		"move_to_current_pane": false
+	}
+
+	```
 
 ## Credits
 


### PR DESCRIPTION
Resolves #12 by adding a new setting called "move_to_current_pane", which can be used to trigger the desired behavior.
